### PR TITLE
Use hyphens instead of underscores and shorter mm- prefix for css class names

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -28,7 +28,7 @@ function mm_shortcode_custom_classes( $classes, $tag, $atts ) {
 
 	// Define attribute key identifiers.
 	$custom_class_prefix = 'mm_class_';
-	$new_custom_class_prefix = 'mm_';
+	$new_custom_class_prefix = 'mm-';
 	$custom_class_key = 'mm_custom_class';
 
 	// Set up classes array.
@@ -41,8 +41,9 @@ function mm_shortcode_custom_classes( $classes, $tag, $atts ) {
 		// Exclude custom class att as this needs to be unprefixed.
 		if ( false !== strpos( $key, $custom_class_prefix ) && $value ) {
 
-			// Replace full custom class prefix with simpler 'mm-' prefix.
+			// Replace custom class prefix with simpler 'mm-' prefix and format appropriately.
 			$key = str_replace( $custom_class_prefix, $new_custom_class_prefix, $key );
+			$key = str_replace( '_', '-', $key );
 			$class_array[] = "{$key}-{$value}";
 		}
 


### PR DESCRIPTION
With your previous commit I'm getting markup like this:

```
<div class="mm-icon-box mm_text_align-center">
    <i class="mm-icon fa fa-adjust"></i>
    <h3>Heading</h3>
    <p>Content</p>      
</div>
```

With this PR I get markup like this:

```
<div class="mm-icon-box mm-text-align-center">
    <i class="mm-icon fa fa-adjust"></i>
    <h3>Heading</h3>
    <p>Content</p>      
</div>
```

What was the reason for using underscores? Just to separate out our classes a bit more? If we're concerned about namespace collisions I think we should go mm-ao- or mm-c- or mmc- (components) before going mm_, although I could be convinced if you have a reason in mind.
