### PR TITLE
Set up package.json and Gruntfile.js for SCSS/CSS task-running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/.sass-cache/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,48 @@
+module.exports = function(grunt) {
+
+	// Project configuration.
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+		sass: {
+			dist: {
+				options: {
+					style: 'expanded'
+				},
+				files: {
+					'css/mm-components-public.css' : 'scss/mm-components-public.scss'
+				}
+			}
+		},
+		watch: {
+			css: {
+				files: '**/*.scss',
+				tasks: ['sass'],
+				options: {
+					livereload: true,
+				}
+			}
+		},
+		postcss: {
+			options: {
+				processors: [
+					require('pixrem')(), // Adds pixel fallbacks for rem units.
+					require('autoprefixer')({browsers: 'last 2 versions'}), // Adds vendor prefixes where required; removes redundant prefixes.
+					require('cssnano')() // Optimizes and minifies resulting CSS output.
+				]
+			},
+			dist: {
+				src: 'css/*.css'
+			}
+		}
+
+	});
+
+	// Load Grunt plugins.
+	grunt.loadNpmTasks('grunt-contrib-sass');
+	grunt.loadNpmTasks('grunt-contrib-watch');
+	grunt.loadNpmTasks('grunt-postcss');
+
+	// Configure default task(s).
+	grunt.registerTask('default', ['watch']);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "mm-components",
+	"version": "0.1.0",
+	"description": "[WordPress] Custom components and functionality for WordPress.",
+	"main": "Gruntfile.js",
+	"directories": {
+		"doc": "docs"
+	},
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/MIGHTYminnow/mm-components.git"
+	},
+	"author": "MIGHTYminnow",
+	"license": "ISC",
+	"bugs": {
+		"url": "https://github.com/MIGHTYminnow/mm-components/issues"
+	},
+	"homepage": "https://github.com/MIGHTYminnow/mm-components#readme",
+	"devDependencies": {
+		"autoprefixer": "^6.0.3",
+		"cssnano": "^3.3.1",
+		"grunt": "^0.4.5",
+		"grunt-contrib-sass": "^0.9.2",
+		"grunt-contrib-watch": "^0.6.1",
+		"grunt-postcss": "^0.6.0",
+		"pixrem": "^3.0.0"
+	}
+}


### PR DESCRIPTION
Configured Grunt tasks to compile SCSS (including a handy watch task), as well as some PostCSS tasks that can be used to optimize the final CSS output.

I also added a .gitignore file to keep the /node_modules/ and /.sass-cache/ directories out of the git repository.
