### PR TITLE
Revert pill button back to border radius 50px.

### DIFF
--- a/scss/mm-components-public.scss
+++ b/scss/mm-components-public.scss
@@ -348,7 +348,7 @@ a.mm-button {
 		border-radius: 5px;
 	}
 	&.pill {
-		border-radius: 100%;
+		border-radius: 50px;
 	}
 }
 


### PR DESCRIPTION
Revert pill button back to `border-radius: 50px` because `border-radius: 100%` causes pill button to distort from pill shape to an oval shape (see image for example of `border-radius: 100%`).
![distorted-pill-button](https://cloud.githubusercontent.com/assets/9504864/10892917/e3017eac-815a-11e5-8d0a-8a878065ed3b.png)
