### PR TITLE
Change pill button border radius back to 50px

### DIFF
--- a/css/mm-components-public.css
+++ b/css/mm-components-public.css
@@ -103,7 +103,7 @@ a.mm-button.rounded {
 }
 
 a.mm-button.pill {
-  border-radius: 100%;
+  border-radius: 50px;
 }
 
 /* Button Styles & Colors */

--- a/scss/mm-components-public.scss
+++ b/scss/mm-components-public.scss
@@ -348,7 +348,7 @@ a.mm-button {
 		border-radius: 5px;
 	}
 	&.pill {
-		border-radius: 100%;
+		border-radius: 50px;
 	}
 }
 


### PR DESCRIPTION
The pill button's shape was distorted from a pill shape to an oval when `border-radius: 100%` was set. This reverts the button's border-radius back to 50px to maintain the button's shape. See attached image for an example of the distortion caused by `border-radius: 100%`.

![distorted-pill-button](https://cloud.githubusercontent.com/assets/9504864/10893131/03bdd824-815c-11e5-9732-5d2ceff05766.png)
