### PR TITLE
Add Shortcake integration to Mm Button

### DIFF
--- a/components/button/button.php
+++ b/components/button/button.php
@@ -214,6 +214,110 @@ function mm_vc_button() {
 	) );
 }
 
+add_action( 'register_shortcode_ui', 'shortcode_ui_for_mm_button');
+/**
+ * Shortcake UI add-on.
+ *
+ * @since  1.0.0
+ */
+function shortcode_ui_for_mm_button() {
+
+	$button_styles         = mm_get_button_styles( 'mm-button' );
+	$button_border_weights = mm_get_button_border_weights( 'mm-button' );
+	$button_corner_styles  = mm_get_button_corner_styles( 'mm-button' );
+	$colors                = mm_get_colors( 'mm-button' );
+	$text_alignment        = mm_get_text_alignment( 'mm-button' );
+
+	if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+		shortcode_ui_register_for_shortcode(
+			'mm_button',
+			array(
+				'label' => esc_html__( 'Mm Button', 'mm-components' ),
+				'listItemImage' => MM_COMPONENTS_ASSETS_URL . 'component-icon.png',
+				'post_type'     => array( 'post', 'page' ),
+				'attrs'             => array(
+					array(
+						'label'       => esc_html__( 'URL', 'mm-components' ),
+						'attr'        => 'link',
+						'type'        => 'url',
+						'description' => esc_html__( 'Enter the full URL for the button.', 'mm-components' ),
+					),
+					array(
+						'label'       => esc_html( 'Link Title', 'mm-components' ),
+						'attr'        => 'link_title',
+						'type'        => 'text',
+						'description' => esc_html__( 'Enter the link title (optional)', 'mm-components' ),
+					),
+					array(
+						'label'       => esc_html( 'Link Target', 'mm-components' ),
+						'attr'        => 'link_target',
+						'type'        => 'text',
+						'description' => esc_html__( 'Enter the link target (optional)', 'mm-components' ),
+					),
+					array(
+						'label'       => esc_html( 'Class', 'mm-components' ),
+						'attr'        => 'class',
+						'type'        => 'text',
+						'description' => esc_html__( 'List any CSS classes you would like to add.', 'mm-components' ),
+					),
+					array(
+						'label'       => esc_html__( 'Style', 'mm-components' ),
+						'attr'        => 'style',
+						'type'        => 'select',
+							'options' => $button_styles,
+					),
+					array(
+						'label'       => esc_html__( 'Border Weight', 'mm-components' ),
+						'attr'        => 'border_weight',
+						'type'        => 'select',
+							'options' => $button_border_weights,
+					),
+					array(
+						'label'       => esc_html__( 'Corner Style', 'mm-components' ),
+						'attr'        => 'corner_style',
+						'type'        => 'select',
+							'options' => $button_corner_styles,
+					),
+					array(
+						'label'       => esc_html__( 'Color', 'mm-components' ),
+						'attr'        => 'color',
+						'type'        => 'select',
+							'options' => $colors,
+					),
+					array(
+						'label'       => esc_html__( 'Button Size', 'mm-components' ),
+						'attr'        => 'size',
+						'type'        => 'select',
+							'options' => array(
+								esc_html__( 'Normal', 'mm-components' ) => 'normal-size',
+								esc_html__( 'Small', 'mm-components' )  => 'small',
+								esc_html__( 'Large', 'mm-components' )  => 'large',
+							),
+					),
+					array(
+						'label'       => esc_html__( 'Full Width Button?', 'mm-button' ),
+						'attr'        => 'full_width',
+						'type'        => 'checkbox',
+						'description' => esc_html__( 'Choosing full-width will make the button take up the width of its container', 'mm-components' ),
+					),
+					array(
+						'label'       => esc_html__( 'Button Alignment', 'mm-components' ),
+						'attr'        => 'alignment',
+						'type'        => 'select',
+							'options' => $text_alignment,
+					),
+					array(
+						'label'       => esc_html( 'Button Text', 'mm-components' ),
+						'attr'        => 'button_text',
+						'type'        => 'text',
+						'description' => esc_html__( 'Enter the button text.', 'mm-components' ),
+					),
+				),
+			)
+		);
+	}
+}
+
 add_action( 'widgets_init', 'mm_components_register_button' );
 /**
  * Register the button widget.


### PR DESCRIPTION
This is for illustrative purposes more than anything (i.e. to illustrate how easy it is to integrate Shortcake). The button now can integrate with [Shortcake](https://wordpress.org/plugins/shortcode-ui/), which means users can have a more visual UI-focused interaction with the button without paying for Visual Composer.

To get the most out of Shortcake, we'd want to integrate our styles into the admin styles so that the user can see a preview of the component in the screen.

Do whatever you want with this. I just wanted to try something new!
