### PR TITLE
Added a better URL validation method.

### DIFF
--- a/components/blockquote/blockquote.php
+++ b/components/blockquote/blockquote.php
@@ -63,7 +63,7 @@ function mm_blockquote( $args ) {
 
 		<?php if ( ! empty( $citation ) ) : ?>
 
-			<?php if ( ! empty( $citation_link ) ) : ?>
+			<?php if ( filter_var( $citation_link, FILTER_VALIDATE_URL ) !== FALSE ) : ?>
 				<a href="<?php echo esc_url( $citation_link ) ?>" title="<?php echo esc_attr( $citation_link_title ); ?>" target="<?php echo esc_attr( $citation_link_target ); ?>"><cite><?php echo esc_html( $citation ); ?></cite></a>
 			<?php else : ?>
 				<cite><?php echo esc_html( $citation ); ?></cite>


### PR DESCRIPTION
Previous method was not enough since $citation_link was set to "||" on a scenario where the user first sets a link for the citation and then removes the link from the citation. For some reason VC returns the "||" string when all fields (url, title and target) are empty after they were filled up at least once.
