### PR TITLE
Rework mm posts to allow multiple filtering instances on a single page

### DIFF
--- a/components/posts/posts.php
+++ b/components/posts/posts.php
@@ -58,7 +58,6 @@ function mm_posts( $args ) {
 	$ajax_filter     = mm_true_or_false( $args['ajax_filter'] );
 	$filter_style    = sanitize_text_field( $args['filter_style'] );
 	$pagination      = sanitize_text_field( $args['pagination'] );
-	$data_atts       = '';
 
 	// Get Mm classes.
 	$mm_classes = apply_filters( 'mm_components_custom_classes', '', $component, $args );

--- a/components/posts/posts.php
+++ b/components/posts/posts.php
@@ -58,6 +58,7 @@ function mm_posts( $args ) {
 	$ajax_filter     = mm_true_or_false( $args['ajax_filter'] );
 	$filter_style    = sanitize_text_field( $args['filter_style'] );
 	$pagination      = sanitize_text_field( $args['pagination'] );
+	$data_atts       = '';
 
 	// Get Mm classes.
 	$mm_classes = apply_filters( 'mm_components_custom_classes', '', $component, $args );
@@ -151,29 +152,33 @@ function mm_posts( $args ) {
 
 	ob_start(); ?>
 
-	<?php do_action( 'mm_posts_before', $query, $context, $args ); ?>
+	<div class="mm-posts-wrapper">
 
-	<div class="<?php echo esc_attr( $mm_classes ); ?> <?php echo esc_attr( $masonry_class ); ?>" >
+		<?php do_action( 'mm_posts_before', $query, $context, $args ); ?>
 
-		<?php do_action( 'mm_posts_before_loop', $query, $context, $args ); ?>
+		<div class="<?php echo esc_attr( $mm_classes ); echo esc_attr( $masonry_class );?>" <?php echo mm_posts_get_data_attributes( $query, $context, $args ); ?> >
 
-		<div class="mm-posts-loop">
+			<?php do_action( 'mm_posts_before_loop', $query, $context, $args ); ?>
 
-			<?php while ( $query->have_posts() ) : $query->the_post(); ?>
+			<div class="mm-posts-loop">
 
-				<?php setup_postdata( $query->post ); ?>
+				<?php while ( $query->have_posts() ) : $query->the_post(); ?>
 
-				<?php echo mm_posts_article( $post, $context, $args ); ?>
+					<?php setup_postdata( $query->post ); ?>
 
-			<?php endwhile; ?>
+					<?php echo mm_posts_article( $post, $context, $args ); ?>
+
+				<?php endwhile; ?>
+
+			</div>
+
+			<?php do_action( 'mm_posts_after_loop', $query, $context, $args ); ?>
 
 		</div>
 
-		<?php do_action( 'mm_posts_after_loop', $query, $context, $args ); ?>
+		<?php do_action( 'mm_posts_after', $query, $context, $args ); ?>
 
 	</div>
-
-	<?php do_action( 'mm_posts_after', $query, $context, $args ); ?>
 
 	<?php
 
@@ -212,10 +217,6 @@ function mm_posts_register_default_hooks( $context, $args ) {
 
 	if ( mm_true_or_false( $args['ajax_filter'] ) ) {
 		add_action( 'mm_posts_before', 'mm_posts_output_taxonomy_term_filter', 10, 3 );
-	}
-
-	if ( mm_true_or_false( $args['ajax_filter'] ) || $args['pagination'] == 'ajax-pagination' ) {
-		add_action( 'mm_posts_before', 'mm_posts_output_js_data_var', 10, 3 );
 	}
 
 	if ( mm_true_or_false( $args['masonry'] ) ) {
@@ -401,37 +402,46 @@ function mm_posts_output_taxonomy_term_filter( $query, $context, $args ) {
  *
  * @return  string              The category filters HTML.
  */
-function mm_posts_get_js_data_var( $query, $context, $args ) {
+function mm_posts_get_data_attributes( $query, $context, $args ) {
 
-	$args['total_pages']    = esc_attr( $query->max_num_pages );
-	$args['total_posts']    = esc_attr( $query->found_posts );
-	$args['global_post_id'] = esc_attr( $context->ID );
+	$data_atts = array();
+	$data_args = array(
+		'query_type',
+		'post_ids',
+		'post_type',
+		'taxonomy',
+		'term',
+		'heading_level',
+		'per_page',
+		'pagination',
+		'template',
+		'show_featured_image',
+		'featured_image_size',
+		'show_post_info',
+		'show_post_meta',
+		'use_post_content',
+		'filter_style',
+		'link_title',
+		'masonry',
+		'current_page',
+	);
 
-	ob_start();
+   // Convert args to data-* attributes.
+   foreach ( $data_args as $data_arg ) {
+       if ( ! empty( $args[ $data_arg ] ) ) {
+           $data_atts[] = 'data-' . str_replace( '_', '-', $data_arg ) . '=' . (string)$args[ $data_arg ];
+       }
+   }
 
-	?>
-	<script type="text/javascript">
-	    var mmPostsData = <?php echo json_encode( $args );?>;
+   // Add special data attributes.
+   $data_atts[] = 'data-total-pages=' . $query->max_num_pages;
+   $data_atts[] = 'data-total-posts=' . $query->found_posts;
+   $data_atts[] = 'data-global-post-id=' . $context->ID;
 
-	</script>
-	<?php
+   // Convert to a string.
+   $data_atts = esc_attr( implode( ' ', $data_atts ) );
 
-    return apply_filters( 'mm_posts_get_js_data_var', ob_get_clean(), $query, $context, $args );
-}
-
-/**
- * Echo the js var data script.
- *
- * @since   1.0.0
- *
- * @param   WP_Query  $query    The query object.
- * @param   WP_Post   $context  The global post object.
- * @param   array     $args     The instance args.
- *
- * @return  string              The category filters HTML.
- */
-function mm_posts_output_js_data_var( $query, $context, $args ) {
-	echo mm_posts_get_js_data_var( $query, $context, $args );
+   return apply_filters( 'mm_posts_data_attributes', $data_atts, $query, $context, $args );
 }
 
 /**

--- a/js/mm-posts-ajax.js
+++ b/js/mm-posts-ajax.js
@@ -1,46 +1,82 @@
 var $ = jQuery;
 
+var mm_posts_data = function( $mmPosts ) {
+	//Grab MM posts atts from data.
+	$mmPosts.each( function() {
+		$this = $( this );
+		currentId         = $this.data( 'current-post-id' );
+		queryType         = $this.data( 'query-type' );
+		postIds           = $this.data( 'post-ids' );
+		postType          = $this.data( 'post-type' );
+		taxonomy          = $this.data( 'taxonomy' );
+		headingLevel      = $this.data( 'heading-level' );
+		perPage           = $this.data( 'per-page' );
+		pagination        = $this.data( 'pagination' );
+		template          = $this.data( 'template' );
+		showFeaturedImage = $this.data( 'show-featured-image' );
+		featuredImageSize = $this.data( 'featured-image-size' );
+		showPostInfo      = $this.data( 'show-post-info' );
+		showPostMeta      = $this.data( 'show-post-meta' );
+		usePostContent    = $this.data( 'use-post-content' );
+		linkTitle         = $this.data( 'link-title' );
+		masonry           = $this.data( 'masonry' );
+		fallbackImage     = $this.data( 'fallback-image' );
+		imageTag          = $this.data( 'image-tag' );
+		imageTag          = $this.data( 'paged' );
+		totalPages        = $this.data( 'total-pages' );
+		totalPosts        = $this.data( 'total-posts' );
+		filterStyle       = $this.data( 'filter-style' );
+		paged             = $this.data( 'paged' );
+
+	});
+
+}
+
+
 var mm_posts_ajax_data = function( newTerm, newPageVal ) {
 
 	data = {
 		action            : 'mm_posts_ajax_filter',
 		currentPage       : newPageVal,
-		globalPostId      : mmPostsData.global_post_id,
-		taxonomy          : mmPostsData.taxonomy,
-		queryType         : mmPostsData.query_type,
-		postIds           : mmPostsData.postIds,
-		postType          : mmPostsData.post_type,
+		currentId         : currentId,
+		taxonomy          : taxonomy,
+		queryType         : queryType,
+		postIds           : postIds,
+		postType          : postType,
 		term              : newTerm,
-		headingLevel      : mmPostsData.heading_level,
-		perPage           : mmPostsData.per_page,
-		paged             : mmPostsData.paged,
-		pagination        : mmPostsData.pagination,
-		template          : mmPostsData.template,
-		showFeaturedImage : mmPostsData.show_featured_image,
-		featuredImageSize : mmPostsData.featured_image_size,
-		showPostInfo      : mmPostsData.show_post_info,
-		showPostMeta      : mmPostsData.show_post_meta,
-		usePostContent    : mmPostsData.use_post_content,
-		linkTitle         : mmPostsData.link_title,
-		masonry           : mmPostsData.masonry,
-		totalPosts        : mmPostsData.total_posts,
-		totalPages        : mmPostsData.total_pages,
-		filterStyle       : mmPostsData.filter_style
+		headingLevel      : headingLevel,
+		perPage           : perPage,
+		paged             : paged,
+		pagination        : pagination,
+		template          : template,
+		showFeaturedImage : showFeaturedImage,
+		featuredImageSize : featuredImageSize,
+		showPostInfo      : showPostInfo,
+		showPostMeta      : showPostMeta,
+		usePostContent    : usePostContent,
+		linkTitle         : linkTitle,
+		masonry           : masonry,
+		fallbackImage     : fallbackImage,
+		imageTag          : imageTag,
+		totalPosts        : totalPosts,
+		totalPages        : totalPages,
+		filterStyle       : filterStyle
 	};
 }
 
 var mm_posts_ajax_filter = function( e, newPageVal ) {
 	var $this = $( this );
-	var $mmPosts = $( '.mm-posts' );
+	var $mmPosts = $this.parents( '.mm-posts-wrapper' ).find( '.mm-posts' );
 	var $mmPostsLoop = $mmPosts.find( '.mm-posts-loop' );
+	var $mmLoading = $mmPosts.find( '.mm-loading' );
 	var $filterLinks = $( '.mm-posts-filter a' );
-	var $pagination = $( '.pagination' );
-	var filterStyle = mmPostsData.filter_style;
-	var totalPages = mmPostsData.total_pages;
+	var $pagination = $this.parents( '.mm-posts-wrapper' ).find( '.pagination' );
 	var newTerm;
 	var $termText;
 	var $responseObj;
 	var newTotalPages;
+
+	mm_posts_data( $mmPosts );
 
 	e.preventDefault();
 
@@ -49,6 +85,8 @@ var mm_posts_ajax_filter = function( e, newPageVal ) {
 	$filterLinks.unbind( 'click' );
 
 	$( '.mm-posts-filter li.active' ).removeClass( 'active' );
+
+	filterStyle = $mmPosts.attr( 'data-filter-style' );
 
 	//Set term-data value to empty when all terms are clicked.
 	if( filterStyle == 'links' ) {
@@ -62,7 +100,6 @@ var mm_posts_ajax_filter = function( e, newPageVal ) {
 	}
 
 	if( filterStyle == 'dropdown' ) {
-		$termText = $this.val();
 
 		if( $this.val() == -1 ) {
 			$termText = '';
@@ -71,7 +108,7 @@ var mm_posts_ajax_filter = function( e, newPageVal ) {
 		}
 	}
 
-	$( '.mm-loading' ).show();
+	$mmLoading.show();
 
 	$this.parent( 'li' ).addClass( 'active' );
 
@@ -111,7 +148,7 @@ var mm_posts_ajax_filter = function( e, newPageVal ) {
 			$( '.mm-posts-loop' ).before( '<span class="no-results">No Results Found.</span>' );
 		}
 
-		$( '.mm-loading' ).hide();
+		$mmLoading.hide();
 
 		//Remove loading text and total posts markup.
 		$mmPosts.find( '.ajax-total-pages' ).remove();
@@ -125,29 +162,20 @@ var mm_posts_ajax_filter = function( e, newPageVal ) {
 
 var mm_posts_ajax_pagination = function( newTerm ) {
 	$this = $( this );
-	var $mmPosts = $( '.mm-posts' );
+	var $mmPosts = $this.prev( '.mm-posts' );
 	var $mmPostsLoop = $mmPosts.find( '.mm-posts-loop' );
+	var $mmLoading = $mmPosts.parent( '.mm-posts-wrapper' ).find( '.mm-loading' );
 	var $paginationWrapper = $( '.mm-posts-ajax-pagination-wrapper' );
-	var $paginationLinks = $( '.pagination a' );
-	var $page;
-	var $responseObj;
-	var newPageVal;
-	var newTerm;
-	var postsPerPage;
-	var pageNumber;
-	var pageNumberRounded;
+	var newPageVal = $this.find( 'li.active a' ).text();;
+	var newTerm = $mmPosts.attr( 'data-term' );;
 
-	//Set page-data value to the text of current clicked page number.
-
-	newPageVal = $paginationWrapper.find( '.pagination li.active a' ).text();
-
-	newTerm = mmPostsData.term;
+	mm_posts_data( $mmPosts );
 
 	mm_posts_ajax_data( newTerm, newPageVal );
 
 	$mmPostsLoop.css({ "visibility" : "hidden" });
 
-	$( '.mm-loading' ).show();
+	$mmLoading.show();
 
 	// Make the AJAX request.
 	$.post( ajaxurl, data, function( response ) {
@@ -161,9 +189,7 @@ var mm_posts_ajax_pagination = function( newTerm ) {
 
 		$mmPosts.find( '.ajax-total-pages' ).remove();
 
-		$( '.mm-loading' ).hide();
-
-		$( '.pagination li:not(.disabled)' ).on( 'click', mm_posts_ajax_pagination );
+		$mmLoading.hide();
 
 	});
 
@@ -171,27 +197,34 @@ var mm_posts_ajax_pagination = function( newTerm ) {
 
 jQuery( document ).ready( function( $ ) {
 
-	var totalPages;
 	var $mmPosts = $( '.mm-posts' );
+	var $mmPostsFilterWrapper = $( '.mm-posts-filter-wrapper');
+	var $mmPostsPaginationWrapper = $( '.mm-posts-ajax-pagination-wrapper' );
 
 	loading = '<i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw mm-loading"></i>';
 	$( '.mm-posts' ).prepend( loading );
 	$( '.mm-loading' ).hide();
 
+	//loop overy every mm posts instance.
+	$mmPosts.each( function() {
+		var $this = $( this );
+		var $paginationWrapper = $this.parents( '.mm-posts-wrapper' ).find( '.mm-posts-ajax-pagination-wrapper' );
+		totalPages = $this.data( 'total-pages' );
+
+		//Only run AJAX pagination if activated.
+		if ( $this.hasClass( 'mm-ajax-pagination' ) ) {
+			$paginationWrapper.twbsPagination({
+			    totalPages: totalPages,
+			    last : false,
+			    first :false,
+			    initiateStartPageClick: false,
+			   	onPageClick: mm_posts_ajax_pagination,
+			});
+		}
+	});
+
 	//Runs the AJAX filter.
 	$( '.mm-posts-filter .cat-item a').on( 'click', mm_posts_ajax_filter );
 	$( '.mm-posts-filter #term_dropdown' ).on( 'change', mm_posts_ajax_filter );
-
-	//Only run AJAX pagination if activated.
-	if ( $mmPosts.hasClass( 'mm-ajax-pagination' ) ) {
-
-		$( '.mm-posts-ajax-pagination-wrapper' ).twbsPagination({
-		    totalPages: mmPostsData.total_pages,
-		    last : false,
-		    first :false
-		});
-
-		$( '.pagination li:not(.disabled)' ).on( 'click', mm_posts_ajax_pagination );
-	}
 
 });


### PR DESCRIPTION
I opted to go with data attributes to handle all of the ajax filtering. It was getting very difficult to handle multiple instances of the components on a single page using a JS object. 
